### PR TITLE
[OSX Fix] Update shebang and add OSX serial ports

### DIFF
--- a/nrfmon.tcl
+++ b/nrfmon.tcl
@@ -1,4 +1,4 @@
-#!/usr/bin/tclsh8.6
+#!/usr/bin/env tclsh8.6
 
 ## ------------------------------------------------------
 ## A software spectrum analyzer for the RF12B radio module
@@ -1372,7 +1372,7 @@ proc enumerate what {
 
 	switch -glob -nocase -- $what {
 		"ports" {
-			lappend out {*}[glob -nocomplain /dev/ttyUSB* /dev/ttyACM* /dev/tty.usbserial*] {*}[WinListSerialPorts]
+			lappend out {*}[glob -nocomplain /dev/ttyUSB* /dev/ttyACM* /dev/tty.usbserial* /dev/cu.usbmodem*] {*}[WinListSerialPorts]
 			if {[llength $out]} {
 				set out [concat {{}} $out]
 			}


### PR DESCRIPTION
nrfmon requires tcl8.6, but OSX Yosemite only provides 8.4 and/or 8.5. You can install tclsh8.6 (>=8.6.3) from ActiveState, but this installs to /usr/local/bin. This patch updates the shebang to use /bin/env in order to start tclsh8.6 from the correct place for OSX and Linux.

The second part of the patch adds OSX serial ports /dev/cu.usbmodem\* to the port-enumerator so nrfmon can find them.

Note: Untested on linux
